### PR TITLE
Add init:create command

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,18 @@
 # laravel-app-init
-An application initialiser that - like migrations - keeps track of on-deploy application commits
+An application initialiser that - like migrations - keeps track of on-deploy application commits.
+
+## Usage
+
+Run pending initialisation commands:
+
+```bash
+php artisan app:init
+```
+
+Create a new init class:
+
+```bash
+php artisan init:create MyInitName
+```
+
+This will create a new file in the `inits` directory with a timestamped prefix.

--- a/src/Console/Commands/CreateInitCommand.php
+++ b/src/Console/Commands/CreateInitCommand.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace SebenzaTaxi\LaravelAppInit\Console\Commands;
+
+use Carbon\Carbon;
+use Illuminate\Console\Command;
+use Illuminate\Support\Str;
+
+class CreateInitCommand extends Command
+{
+    protected $signature = 'init:create {name : The name of the init file}';
+
+    protected $description = 'Create a new application init file';
+
+    public function handle(): void
+    {
+        $name = Str::snake($this->argument('name'));
+        $timestamp = Carbon::now()->format('Y_m_d_His');
+        $filename = sprintf('%s_%s.php', $timestamp, $name);
+
+        $directory = base_path('inits');
+        if (!is_dir($directory)) {
+            mkdir($directory, 0755, true);
+        }
+
+        $path = $directory . DIRECTORY_SEPARATOR . $filename;
+
+        $stub = <<<PHP
+<?php
+
+use SebenzaTaxi\\LaravelAppInit\\Libraries\\AppInitCommand;
+
+return new class extends AppInitCommand
+{
+    public function up()
+    {
+        //
+    }
+};
+PHP;
+
+        file_put_contents($path, $stub);
+
+        $this->info("Init created: {$filename}");
+    }
+}

--- a/src/Providers/AppInitServiceProvider.php
+++ b/src/Providers/AppInitServiceProvider.php
@@ -4,6 +4,7 @@ namespace SebenzaTaxi\LaravelAppInit\Providers;
 
 use Illuminate\Support\ServiceProvider;
 use SebenzaTaxi\LaravelAppInit\Console\Commands\ApplicationInitialisationHandlerCommand;
+use SebenzaTaxi\LaravelAppInit\Console\Commands\CreateInitCommand;
 
 class AppInitServiceProvider extends ServiceProvider
 {
@@ -21,7 +22,8 @@ class AppInitServiceProvider extends ServiceProvider
         // Console command
         if ($this->app->runningInConsole()) {
             $this->commands([
-                ApplicationInitialisationHandlerCommand::class
+                ApplicationInitialisationHandlerCommand::class,
+                CreateInitCommand::class,
             ]);
         }
     }


### PR DESCRIPTION
## Summary
- add `CreateInitCommand` to generate init classes
- register new command in service provider
- document `init:create` usage in README

## Testing
- `php --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_683a7d409f3c8320ac5113bc227fadca